### PR TITLE
Fixed crash when variation is a pass

### DIFF
--- a/wgo/player.js
+++ b/wgo/player.js
@@ -75,7 +75,7 @@ var update_board = function(e) {
 	// add variantion letters
 	if(e.node.children.length > 1) {
 		for(var i = 0; i < e.node.children.length; i++) {
-			if(e.node.children[i].move)	add.push({
+			if(e.node.children[i].move && !e.node.children[i].move.pass)	add.push({
 				type: "LB",
 				text: String.fromCharCode(65+i),
 				x: e.node.children[i].move.x,


### PR DESCRIPTION
If a variant move is a pass then WGo tries to put letter on undefined coordinates. This just skips showing pass as variant.
