### PR TITLE
Add ability to keep edits from edit mode

### DIFF
--- a/wgo/kifu.js
+++ b/wgo/kifu.js
@@ -103,66 +103,66 @@ var sgf_write_node = function(node, output) {
 	if(node.move) {
 		var move = "";
 		if(!node.pass) move = sgf_coordinates(node.move.x, node.move.y);
-		
+
 		if(node.move.c == WGo.B) output.sgf += "B["+move+"]";
 		else output.sgf += "W["+move+"]";
 	}
-	
+
 	// setup
 	if(node.setup) {
 		var AB = [];
 		var AW = [];
 		var AE = [];
-		
+
 		for(var i in node.setup) {
 			if(node.setup[i].c == WGo.B) AB.push(sgf_coordinates(node.setup[i].x, node.setup[i].y));
 			else if(node.setup[i].c == WGo.W) AW.push(sgf_coordinates(node.setup[i].x, node.setup[i].y));
 			else AE.push(sgf_coordinates(node.setup[i].x, node.setup[i].y));
 		}
-		
+
 		sgf_write_group("AB", AB, output);
 		sgf_write_group("AW", AW, output);
 		sgf_write_group("AE", AE, output);
 	}
-	
+
 	// markup
 	if(node.markup) {
 		var markup = {};
-		
+
 		for(var i in node.markup) {
 			markup[node.markup[i].type] = markup[node.markup[i].type] || [];
 			if(node.markup[i].type == "LB") markup["LB"].push(sgf_coordinates(node.markup[i].x, node.markup[i].y)+":"+sgf_escape(node.markup[i].text));
 			else markup[node.markup[i].type].push(sgf_coordinates(node.markup[i].x, node.markup[i].y));
 		}
-		
+
 		for(var key in markup) {
 			sgf_write_group(key, markup[key], output);
 		}
 	}
-	
+
 	// other
 	var props = node.getProperties();
-	
+
 	for(var key in props) {
 		if(typeof props[key] == "object") continue;
-		
+
 		if(key == "turn") output.sgf += "PL["+(props[key] == WGo.B ? "B" : "W")+"]";
 		else if(key == "comment") output.sgf += "C["+sgf_escape(props[key])+"]";
 		else output.sgf += key+"["+sgf_escape(props[key])+"]";
 	}
-	
+
 	if(node.children.length == 1) {
 		output.sgf += "\n;";
 		sgf_write_node(node.children[0], output);
 	}
 	else if(node.children.length > 1) {
 		for(var key in node.children) {
-			sgf_write_variantion(node.children[key], output);
+			sgf_write_variation(node.children[key], output);
 		}
 	}
 }
 
-var sgf_write_variantion = function(node, output) {
+var sgf_write_variation = function(node, output) {
 	output.sgf += "(\n;";
 	sgf_write_node(node, output);
 	output.sgf += "\n)";


### PR DESCRIPTION
The default edit mode resets any changes made to the kifu when you exit edit mode. This allows you to turn off reset mode so that edits (variations) can be kept and even saved. It defaults to reset mode, so edit behavior shouldn't be affected for anyone who doesn't explicitly opt in.

Also: I removed the "edited: true" property from nodes added in edit mode. It looks like the only place this property is mentioned is here.

I debated probably too long about whether to add a filter on the `toSgf` side that screened out this property when saving a modified SGF, but I ultimately felt less good about modifying the way you're outputting SGFs than I did about removing this seemingly unused property. If there's a reason you want to keep it, let's just figure out a way to filter it out of SGFs on the output side.

(Sorry about all the whitespace in the diffs... you can add ?w=1 (or &w=1) to access Github's secret "ignore whitespace" mode, which will give you a much easier view.)