### PR TITLE
Add the ability to have a solid color behind coordinates

### DIFF
--- a/wgo/player.js
+++ b/wgo/player.js
@@ -623,7 +623,13 @@ Player.prototype = {
 	 
 	setCoordinates: function(b) {
 		if(!this.coordinates && b) {
-			this.board.setSection(-0.5, -0.5, -0.5, -0.5);
+			if (this.board.theme.coordinatesBackgroundColor) {
+				// Give coordinates more space is there's a background color behind them
+				// to separate them from the board
+				this.board.setSection(-1, -1, -1, -1);
+			} else {
+				this.board.setSection(-0.5, -0.5, -0.5, -0.5);
+			}
 			this.board.addCustomObject(WGo.Board.coordinates);
 		}
 		else if(this.coordinates && !b) {

--- a/wgo/wgo.js
+++ b/wgo/wgo.js
@@ -243,7 +243,13 @@ Board.themes.default = {
 }
 
 var theme_variable = function(key, board) {
-	return typeof board.theme[key] == "function" ? board.theme[key](board) : board.theme[key];
+	if (!board || typeof board.theme[key] === "undefined") {
+		return undefined;
+	} else if (typeof board.theme[key] === "function") {
+		return board.theme[key](board);
+	} else {
+		return board.theme[key];
+	}
 }
 
 var shadow_handler = {
@@ -779,30 +785,63 @@ Board.coordinates = {
 	grid: {
 		draw: function(args, board) {
 			var ch, t, xright, xleft, ytop, ybottom;
-			
+
+			var coordinatesBackground = theme_variable('coordinatesBackgroundColor', board);
+
+			if (coordinatesBackground) {
+				// Draw a background behind the coordinates
+				this.beginPath();
+				this.moveTo(0, 0);
+				this.lineTo(0, board.height);
+				this.lineTo(board.width, board.height);
+				this.lineTo(board.width, 0);
+				this.lineTo(0, 0);
+				this.closePath();
+
+				this.rect(
+					board.fieldWidth,
+					board.fieldHeight,
+					Math.round(board.width - (board.fieldWidth * 2)),
+					Math.round(board.height - (board.fieldHeight * 2))
+				);
+
+				this.fillStyle = theme_variable('coordinatesBackgroundColor', board);
+				this.fill();
+
+				this.clip();
+				this.save();
+
+				this.restore();
+
+				xright = board.getX(-1.25);
+				xleft = board.getX(board.size + 0.25);
+				ytop = board.getY(-1.25);
+				ybottom = board.getY(board.size + 0.25);
+			} else {
+				xright = board.getX(-0.75);
+				xleft = board.getX(board.size-0.25);
+				ytop = board.getY(-0.75);
+				ybottom = board.getY(board.size-0.25);
+			}
+
 			this.fillStyle = theme_variable("coordinatesColor", board);
 			this.textBaseline="middle";
 			this.textAlign="center";
 			this.font = board.stoneRadius+"px "+(board.font || "");
-			
-			xright = board.getX(-0.75);
-			xleft = board.getX(board.size-0.25);
-			ytop = board.getY(-0.75);
-			ybottom = board.getY(board.size-0.25);
-			
+
 			for(var i = 0; i < board.size; i++) {
 				ch = i+"A".charCodeAt(0);
 				if(ch >= "I".charCodeAt(0)) ch++;
-				
+
 				t = board.getY(i);
 				this.fillText(board.size-i, xright, t);
 				this.fillText(board.size-i, xleft, t);
-				
+
 				t = board.getX(i);
 				this.fillText(String.fromCharCode(ch), t, ytop);
 				this.fillText(String.fromCharCode(ch), t, ybottom);
 			}
-			
+
 			this.fillStyle = "black";
 		}
 	}


### PR DESCRIPTION
For GoKibitz, I wanted to have my coordinates always on and I wanted to give them a background color that separated them from the board itself.

This pull request adds that as an option without affecting any board where the new `coordinatesBackgroundColor` is not set on the theme object.

![2015-01-25 at 1 47 am](https://cloud.githubusercontent.com/assets/176993/5890660/2dda963e-a434-11e4-8b3d-91627a34f206.png)
