### PR TITLE
Fix handling of pass nodes in toSgf() export

### DIFF
--- a/wgo/kifu.js
+++ b/wgo/kifu.js
@@ -102,7 +102,7 @@ var sgf_write_node = function(node, output) {
 	// move
 	if(node.move) {
 		var move = "";
-		if(!node.pass) move = sgf_coordinates(node.move.x, node.move.y);
+		if(!node.move.pass) move = sgf_coordinates(node.move.x, node.move.y);
 		
 		if(node.move.c == WGo.B) output.sgf += "B["+move+"]";
 		else output.sgf += "W["+move+"]";


### PR DESCRIPTION
The pass flag must be checked on the .move property of the node, not on the node itself.

Without this fix, there are nasty null bytes in the exported sgf.