### PR TITLE
Correctly handle data-wgo-move="0"

### DIFF
--- a/wgo/basicplayer.js
+++ b/wgo/basicplayer.js
@@ -475,7 +475,7 @@ BasicPlayer.attributes = {
 	
 	"data-wgo-move": function(value) {
 		var m = parseInt(value);
-		if(m) this.move = m;
+		if(!isNaN(m)) this.move = m;
 		else this.move = eval("({"+value+"})");
 	},
 


### PR DESCRIPTION
The boolean value of 0 is false, so currently it is not possible to show the initial state of an SGF (say if there are setup moves) using data-wgo-move.