### PR TITLE
change MouseEvent property from layerX to offsetX

### DIFF
--- a/wgo/wgo.js
+++ b/wgo/wgo.js
@@ -1153,12 +1153,12 @@ var getMousePos = function(e) {
 
 	var x, y;
 
-	x = e.layerX * this.pixelRatio;
+	x = e.offsetX * this.pixelRatio;
 	x -= this.left;
 	x /= this.fieldWidth;
 	x = Math.round(x);
 
-	y = e.layerY * this.pixelRatio;
+	y = e.offsetY * this.pixelRatio;
 	y -= this.top;
 	y /= this.fieldHeight;
 	y = Math.round(y);


### PR DESCRIPTION
There is a problem that you can not click the board when using iframe with IE and Edge. I think that it is better to use offsetX, offsetY instead of layerX, LayerY of MouseEvent.