### PR TITLE
Add hour to the timer

### DIFF
--- a/wgo/kifu.js
+++ b/wgo/kifu.js
@@ -307,10 +307,14 @@ Kifu.infoFormatters = {
 	TM: function(time) {
 		if(time == 0) return WGo.t("none");
 		
-		var res, t = Math.floor(time/60);
+		var res, t = Math.floor(time/3600);
+
+		if(t == 1) res = "1 "+WGo.t("hour");
+		else if(t > 1) res = t+" "+WGo.t("hours");
 		
-		if(t == 1) res = "1 "+WGo.t("minute");
-		else if(t > 1) res = t+" "+WGo.t("minutes");
+		t = Math.floor((time - t*3600)/60);
+		if(t == 1) res += " 1 "+WGo.t("minute");
+		else if(t > 1) res += " "+t+" "+WGo.t("minutes");
 		
 		t = time%60;
 		if(t == 1) res += " 1 "+WGo.t("second");


### PR DESCRIPTION
<img src="https://i.imgur.com/uAdwurq.png" title="source: imgur.com" width="200"/>

Just a simple tweak that adds hours in the function for `TM`, as I found many pro sgfs last 2 hours or more.